### PR TITLE
Editor forgets datatype settings after save

### DIFF
--- a/src/DataType/GoogleMapEditor.cs
+++ b/src/DataType/GoogleMapEditor.cs
@@ -180,34 +180,31 @@ namespace Umbraco.GoogleMaps.DataType
         {
             base.OnLoad(e);
 
-            if (!this.Page.IsPostBack)
+            if (this._data.Value != null && !string.IsNullOrEmpty(this._data.Value.ToString()))
             {
-                if (this._data.Value != null && !string.IsNullOrEmpty(this._data.Value.ToString()))
+                MapState mapVal = MapState.Deserialize(this._data.Value.ToString());
+
+                if (mapVal != null)
                 {
-                    MapState mapVal = MapState.Deserialize(this._data.Value.ToString());
+                    mapVal.SingleLocation = value.SingleLocation;
+                    mapVal.Language = value.Language;
+                    mapVal.Width = value.Width;
+                    mapVal.Height = value.Height;
+                    mapVal.DrawingTools = value.DrawingTools;
+                    mapVal.SearchBox = value.SearchBox;
+                    mapVal.RichtextEditor = value.RichtextEditor;
+                    mapVal.ZoomControl = value.ZoomControl;
+                    mapVal.PanControl = value.PanControl;
+                    mapVal.StreetViewControl = value.StreetViewControl;
+                    mapVal.ScaleControl = value.ScaleControl;
 
-                    if (mapVal != null)
-                    {
-                        mapVal.SingleLocation = value.SingleLocation;
-                        mapVal.Language = value.Language;
-                        mapVal.Width = value.Width;
-                        mapVal.Height = value.Height;
-                        mapVal.DrawingTools = value.DrawingTools;
-                        mapVal.SearchBox = value.SearchBox;
-                        mapVal.RichtextEditor = value.RichtextEditor;
-                        mapVal.ZoomControl = value.ZoomControl;
-                        mapVal.PanControl = value.PanControl;
-                        mapVal.StreetViewControl = value.StreetViewControl;
-                        mapVal.ScaleControl = value.ScaleControl;
-
-                        this.ctlValue.Value = mapVal.ToJSON();
-                    }
-
+                    this.ctlValue.Value = mapVal.ToJSON();
                 }
-                else
-                {
-                    this.ctlValue.Value = value.ToJSON();
-                }
+
+            }
+            else
+            {
+                this.ctlValue.Value = value.ToJSON();
             }
 
         }


### PR DESCRIPTION
I don't know why the compare tool goes this crazy, all I've done is remove the Page.IsPostBack check.
