### PR TITLE
Revert "Editor forgets datatype settings after save"

### DIFF
--- a/src/DataType/GoogleMapEditor.cs
+++ b/src/DataType/GoogleMapEditor.cs
@@ -180,31 +180,34 @@ namespace Umbraco.GoogleMaps.DataType
         {
             base.OnLoad(e);
 
-            if (this._data.Value != null && !string.IsNullOrEmpty(this._data.Value.ToString()))
+            if (!this.Page.IsPostBack)
             {
-                MapState mapVal = MapState.Deserialize(this._data.Value.ToString());
-
-                if (mapVal != null)
+                if (this._data.Value != null && !string.IsNullOrEmpty(this._data.Value.ToString()))
                 {
-                    mapVal.SingleLocation = value.SingleLocation;
-                    mapVal.Language = value.Language;
-                    mapVal.Width = value.Width;
-                    mapVal.Height = value.Height;
-                    mapVal.DrawingTools = value.DrawingTools;
-                    mapVal.SearchBox = value.SearchBox;
-                    mapVal.RichtextEditor = value.RichtextEditor;
-                    mapVal.ZoomControl = value.ZoomControl;
-                    mapVal.PanControl = value.PanControl;
-                    mapVal.StreetViewControl = value.StreetViewControl;
-                    mapVal.ScaleControl = value.ScaleControl;
+                    MapState mapVal = MapState.Deserialize(this._data.Value.ToString());
 
-                    this.ctlValue.Value = mapVal.ToJSON();
+                    if (mapVal != null)
+                    {
+                        mapVal.SingleLocation = value.SingleLocation;
+                        mapVal.Language = value.Language;
+                        mapVal.Width = value.Width;
+                        mapVal.Height = value.Height;
+                        mapVal.DrawingTools = value.DrawingTools;
+                        mapVal.SearchBox = value.SearchBox;
+                        mapVal.RichtextEditor = value.RichtextEditor;
+                        mapVal.ZoomControl = value.ZoomControl;
+                        mapVal.PanControl = value.PanControl;
+                        mapVal.StreetViewControl = value.StreetViewControl;
+                        mapVal.ScaleControl = value.ScaleControl;
+
+                        this.ctlValue.Value = mapVal.ToJSON();
+                    }
+
                 }
-
-            }
-            else
-            {
-                this.ctlValue.Value = value.ToJSON();
+                else
+                {
+                    this.ctlValue.Value = value.ToJSON();
+                }
             }
 
         }


### PR DESCRIPTION
Christ, I keep doing things in the wrong places. I initially commented on your commit instead of here, sorry:

You should delete this PR, Dejan. It prevents saving data on new maps (with no previous db value, as far as I can see).

I wish I had time to fix it properly, but for now I'll have to live with losing datatype settings on save :-( I will look into it as soon as I have the time! Sorry for the inconvenience and poor testing.
