### PR TITLE
Fix in order to center map in View and Edit mode

### DIFF
--- a/src/Resources/jquery.googlemaps.js
+++ b/src/Resources/jquery.googlemaps.js
@@ -183,7 +183,7 @@ $.fn.GoogleMapEditor = function (options) {
         loadPopupTemplates();
 
         map = new google.maps.Map(container, {
-            center: new google.maps.LatLng(settings.Center.Latitude, settings.Center.Longitude),
+            center: new google.maps.LatLng(settings.mapSettings.Center.Latitude, settings.mapSettings.Center.Longitude),
             zoom: settings.mapSettings.Zoom,
             zoomControl: settings.mapSettings.ZoomControl,
             panControl: settings.mapSettings.PanControl,

--- a/src/Resources/jquery.googlemapview.js
+++ b/src/Resources/jquery.googlemapview.js
@@ -56,7 +56,7 @@ $.fn.GoogleMapViewer = function (options) {
         $(container).show();
 
         map = new google.maps.Map(container, {
-            center: new google.maps.LatLng(settings.Center.Latitude, settings.Center.Longitude),
+            center: new google.maps.LatLng(settings.mapSettings.Center.Latitude, settings.mapSettings.Center.Longitude),
             zoom: settings.mapSettings.Zoom,
             zoomControl: settings.mapSettings.ZoomControl,
             panControl: settings.mapSettings.PanControl,


### PR DESCRIPTION
Fix a bug that the map does not center in the correct center - instead it centers in the original center from the datatype.
